### PR TITLE
Fix/invoice print danfe

### DIFF
--- a/nfe/models/account_invoice.py
+++ b/nfe/models/account_invoice.py
@@ -316,7 +316,7 @@ class AccountInvoice(models.Model):
             datas = {
                 'ids': inv.ids,
                 'model': 'account.invoice',
-                'form': self.read(inv.id)
+                'form': self.read(inv.ids)
             }
 
             return {

--- a/nfe/sped/nfe/processing/processor.py
+++ b/nfe/sped/nfe/processing/processor.py
@@ -32,13 +32,13 @@ class DANFE(DanfePySped):
         super(DANFE, self).__init__()
 
 
-    def gerar_danfe(self):
-        """
-        Remove a geração automática do DANFE para deixar o processo + leve
-        :return:
-        """
-        self.conteudo_pdf = ''
-        return
+    # def gerar_danfe(self):
+    #     """
+    #     Remove a geração automática do DANFE para deixar o processo + leve
+    #     :return:
+    #     """
+    #     self.conteudo_pdf = ''
+    #     return
 
 
 class ProcessadorNFe(ProcessadorNFePySped):


### PR DESCRIPTION
- Corrige o erro _"TypeError: 'int' object is not iterable"_ ao pressionarmos o botão "Imprimir fatura";
- Sobreescrita do método "gerar_danfe" estava impedindo a impressão do DANFE final. Por isso o mesmo foi comentado (temporário). 

[TODO] Buscar uma maneira de desacoplar a geração do DANFE final do processo de envio da NFE
