### PR TITLE
Não criar registro na desserialização da NFe

### DIFF
--- a/nfe_import/service/nfe_serializer.py
+++ b/nfe_import/service/nfe_serializer.py
@@ -69,11 +69,9 @@ class NFeSerializer(object):
         }
         try:
             nfe_references = self._get_nfe_references()
-            ref = self.env['l10n_br_account_product.document.related'].create(
-                nfe_references)
 
             invoice_vals.update(
-                {'fiscal_document_related_ids': [(4, ref.id, None)]})
+                {'fiscal_document_related_ids': [(0, False, nfe_references)]})
         except AttributeError:
             pass
 


### PR DESCRIPTION
Na desserialização de uma NFe, ao invés de criar um `l10n_br_account_product.document.related`, e adicionar a um campo o2m de um registro que talvez nem venha a ser criado, apenas passa os dados
para serem criados no futuro.