### PR TITLE
"button_cancel" chama "action_cancel" em vez do super

### DIFF
--- a/nfe/models/account_invoice.py
+++ b/nfe/models/account_invoice.py
@@ -213,7 +213,7 @@ class AccountInvoice(models.Model):
 
         if ((document_serie_id and fiscal_document_id and not electronic) or
                 not nfe_protocol) or emitente == u'1':
-            return super(AccountInvoice, self).action_cancel()
+            return self.action_cancel()
         else:
             result = self.env['ir.actions.act_window'].for_xml_id(
                 'nfe',


### PR DESCRIPTION
@mileo Poderia me explicar a utilidade da função "button_cancel"?
O botão que a dispara, "cancelar fatura", está presente apenas no formulário da NFe. Se eu quiser, posso  partir de uma coleta, clicar numa das linhas de faturas em ""Informações adicionais" e clicar no botão "action cancel" presente no pop-up aberto, que invoca "action_cancel" diretamente.